### PR TITLE
Change loop to Register Key Mapping function

### DIFF
--- a/griizz-ragdoll/client.lua
+++ b/griizz-ragdoll/client.lua
@@ -1,11 +1,7 @@
 -- Made By Griizz --
 
-Citizen.CreateThread(function() 	
-    while true do 		
-        Citizen.Wait(0) 		
-        if IsControlPressed(1, 243 --[[ "`/~" key ]]) then 		
-            -- https://runtime.fivem.net/doc/natives/#_0xAE99FB955581844A
-            SetPedToRagdoll(GetPlayerPed(-1), 1000, 1000, 0, true, true, false) 
-        end 	
-    end 
+RegisterCommand("ragdoll",function()
+    SetPedToRagdoll(GetPlayerPed(-1), 1000, 1000, 0, true, true, false) 
 end)
+
+RegisterKeyMapping("ragdoll", "Forces the player to ragdoll", "keyboard", "~")


### PR DESCRIPTION
Running a loop to check for a keybind is a deprecated method, especially for small things like this, should be better on performance.